### PR TITLE
Features/checkout

### DIFF
--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -1,19 +1,14 @@
 Spree::Order.class_eval do
   checkout_flow do
+    go_to_state :payment, :if => lambda { |order| order.payment_required? }
     go_to_state :confirm, :if => lambda { |order| order.confirmation_required? }
     go_to_state :complete
   end
   
-  def address_required?
-    false
-  end
-
-  # If true, causes the payment step to happen during the checkout process
   def payment_required?
     false
   end
 
-  # If true, causes the confirmation step to happen during the checkout process
   def confirmation_required?
     true
   end

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -1,0 +1,22 @@
+Spree::Order.class_eval do
+  checkout_flow do
+    go_to_state :address, :if => lambda { |order| order.address_required? } 
+    go_to_state :payment, :if => lambda { |order| order.payment_required? }
+    go_to_state :confirm, :if => lambda { |order| order.confirmation_required? }
+    go_to_state :complete
+  end
+  def address_required?
+    false
+  end
+
+  # If true, causes the payment step to happen during the checkout process
+  def payment_required?
+    false
+  end
+
+  # If true, causes the confirmation step to happen during the checkout process
+  def confirmation_required?
+    true
+  end
+
+end

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -1,7 +1,5 @@
 Spree::Order.class_eval do
   checkout_flow do
-    go_to_state :address, :if => lambda { |order| order.address_required? } 
-    go_to_state :payment, :if => lambda { |order| order.payment_required? }
     go_to_state :confirm, :if => lambda { |order| order.confirmation_required? }
     go_to_state :complete
   end

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -5,6 +5,7 @@ Spree::Order.class_eval do
     go_to_state :confirm, :if => lambda { |order| order.confirmation_required? }
     go_to_state :complete
   end
+  
   def address_required?
     false
   end

--- a/app/views/spree/checkout/_confirm.html.erb
+++ b/app/views/spree/checkout/_confirm.html.erb
@@ -1,0 +1,25 @@
+<fieldset id="order_details" data-hook>
+  <div class="clear"></div>
+  <legend align="center"><%= t('spree.confirm') %></legend>
+  <%= render partial: 'spree/shared/order_details', locals: { order: @order } %>
+</fieldset>
+
+<br />
+
+<div class="form-buttons" data-hook="buttons">
+  <% Spree::Frontend::Config[:require_terms_and_conditions_acceptance].tap do |requires_acceptance| %>
+    <% if requires_acceptance %>
+      <div class="terms_and_conditions" data-hook="terms_and_conditions">
+        <div class="policy"><%= render partial: "spree/checkout/terms_and_conditions" %></div>
+        <%= check_box_tag :accept_terms_and_conditions, 'accepted', false %>
+        <%= label_tag :accept_terms_and_conditions, t('spree.agree_to_terms_of_service') %>
+      </div>
+    <% end %>
+
+    <%= submit_tag t('spree.place_order'),
+      disabled: requires_acceptance,
+      class: "continue button primary #{ 'disabled' if requires_acceptance }" %>
+  <% end %>
+
+  <script>Spree.disableSaveOnClick();</script>
+</div>

--- a/app/views/spree/checkout/_confirm.html.erb
+++ b/app/views/spree/checkout/_confirm.html.erb
@@ -16,9 +16,7 @@
       </div>
     <% end %>
 
-    <%= submit_tag t('spree.place_order'),
-      disabled: requires_acceptance,
-      class: "continue button primary #{ 'disabled' if requires_acceptance }" %>
+    <%= submit_tag t('spree.place_order'), disabled: requires_acceptance, class: "continue button primary #{ 'disabled' if requires_acceptance }" %>
   <% end %>
 
   <script>Spree.disableSaveOnClick();</script>

--- a/app/views/spree/shared/_order_details.html.erb
+++ b/app/views/spree/shared/_order_details.html.erb
@@ -1,0 +1,146 @@
+<div class="row steps-data">
+
+  <% if order.has_checkout_step?("address") %>
+
+    <div class="columns alpha four" data-hook="order-bill-address">
+      <h6><%= t('spree.billing_address') %> <%= link_to "(#{t('spree.actions.edit')})", checkout_state_path(:address) unless order.completed? %></h6>
+      <%= render partial: 'spree/shared/address', locals: { address: order.bill_address } %>
+    </div>
+
+    <% if order.has_checkout_step?("delivery") %>
+      <div class="columns alpha four" data-hook="order-ship-address">
+        <h6><%= t('spree.shipping_address') %> <%= link_to "(#{t('spree.actions.edit')})", checkout_state_path(:address) unless order.completed? %></h6>
+        <%= render partial: 'spree/shared/address', locals: { address: order.ship_address } %>
+      </div>
+
+      <div class="columns alpha four" data-hook="order-shipment">
+        <h6><%= t('spree.shipments') %> <%= link_to "(#{t('spree.actions.edit')})", checkout_state_path(:delivery) unless order.completed? %></h6>
+        <div class="delivery">
+          <% order.shipments.each do |shipment| %>
+            <div>
+              <i class='fa fa-truck'></i>
+              <%= t('spree.shipment_details', stock_location: shipment.stock_location.name, shipping_method: shipment.selected_shipping_rate.name) %>
+            </div>
+          <% end %>
+        </div>
+        <%= render(partial: 'spree/shared/shipment_tracking', locals: {order: order}) if order.shipped? %>
+      </div>
+    <% end %>
+  <% end %>
+
+  <% if order.has_checkout_step?("payment") %>
+    <div class="columns omega four">
+      <h6><%= t('spree.payment_information') %> <%= link_to "(#{t('spree.actions.edit')})", checkout_state_path(:payment) unless order.completed? %></h6>
+      <div class="payment-info">
+        <% order.payments.valid.each do |payment| %>
+          <%= render payment %><br/>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+</div>
+
+<hr />
+
+<table id='line-items' class="index columns alpha omega sixteen" data-hook="order_details">
+  <col width="15%" valign="middle" halign="center">
+  <col width="70%" valign="middle">
+  <col width="5%" valign="middle" halign="center">
+  <col width="5%" valign="middle" halign="center">
+  <col width="5%" valign="middle" halign="center">
+
+  <thead data-hook>
+    <tr data-hook="order_details_line_items_headers">
+      <th colspan="2"><%= t('spree.item') %></th>
+      <th class="price"><%= t('spree.price') %></th>
+      <th class="qty"><%= t('spree.qty') %></th>
+      <th class="total"><span><%= t('spree.total') %></span></th>
+    </tr>
+  </thead>
+
+  <tbody data-hook>
+    <% order.line_items.each do |item| %>
+      <tr data-hook="order_details_line_item_row">
+        <td data-hook="order_item_image">
+          <%= link_to(render('spree/shared/image',
+                             image: (item.variant.images.first || item.variant.product.gallery.images.first),
+                             size: :small), item.variant.product) %>
+        </td>
+        <td data-hook="order_item_description">
+          <h4><%= item.variant.product.name %></h4>
+          <%= truncated_product_description(item.variant.product) %>
+          <%= "(" + item.variant.options_text + ")" unless item.variant.option_values.empty? %>
+        </td>
+        <td data-hook="order_item_price" class="price"><span><%= item.single_money.to_html %></span></td>
+        <td data-hook="order_item_qty"><%= item.quantity %></td>
+        <td data-hook="order_item_total" class="total"><span><%= item.display_amount.to_html %></span></td>
+      </tr>
+    <% end %>
+  </tbody>
+  <tfoot id="order-total" data-hook="order_details_total">
+    <tr class="total">
+      <td colspan="4"><b><%= t('spree.order_total') %>:</b></td>
+      <td class="total"><span id="order_total"><%= order.display_order_total_after_store_credit.to_html %></span></td>
+    </tr>
+  </tfoot>
+
+  <tfoot id="subtotal" data-hook="order_details_subtotal">
+    <tr class="total" id="subtotal-row">
+      <td colspan="4"><b><%= t('spree.subtotal') %>:</b></td>
+      <td class="total"><span><%= order.display_item_total.to_html %></span></td>
+    </tr>
+  </tfoot>
+
+  <% if order.line_item_adjustments.exists? %>
+    <% if order.line_item_adjustments.promotion.eligible.exists? %>
+      <tfoot id="price-adjustments" data-hook="order_details_price_adjustments">
+        <% order.line_item_adjustments.promotion.eligible.group_by(&:label).each do |label, adjustments| %>
+          <tr class="total">
+            <td colspan="4"><%= t('spree.promotion') %>: <strong><%= label %></strong></td>
+            <td class="total"><span><%= Spree::Money.new(adjustments.sum(&:amount), currency: order.currency) %></span></td>
+          </tr>
+        <% end %>
+      </tfoot>
+    <% end %>
+  <% end %>
+
+  <tfoot id='shipment-total'>
+    <% order.shipments.group_by { |s| s.selected_shipping_rate.name }.each do |name, shipments| %>
+      <tr class="total" data-hook='shipment-row'>
+        <td colspan="4"><%= t('spree.shipping') %>: <strong><%= name %></strong></td>
+        <td class="total"><span><%= Spree::Money.new(shipments.sum(&:total_before_tax), currency: order.currency).to_html %></span></td>
+      </tr>
+    <% end %>
+  </tfoot>
+
+  <% if order.all_adjustments.tax.exists? %>
+    <tfoot id="tax-adjustments" data-hook="order_details_tax_adjustments">
+      <% order.all_adjustments.tax.group_by(&:label).each do |label, adjustments| %>
+        <tr class="total">
+          <td colspan="4"><%= t('spree.tax') %>: <strong><%= label %></strong></td>
+          <td class="total"><span><%= Spree::Money.new(adjustments.sum(&:amount), currency: order.currency) %></span></td>
+        </tr>
+      <% end %>
+    </tfoot>
+  <% end %>
+
+  <% if order.total_applicable_store_credit > 0.0 %>
+    <tfoot id="store-credit" data-hook="order_details_store_credit">
+      <tr class="total">
+        <td colspan='4'><%= t('spree.store_credit.store_credit') %>:</td>
+        <td class='total'><span><%= order.display_total_applicable_store_credit.to_html %></span></td>
+      </tr>
+    </tfoot>
+  <% end %>
+
+  <tfoot id="order-charges" data-hook="order_details_adjustments">
+    <% order.adjustments.eligible.each do |adjustment| %>
+    <% next if (adjustment.source_type == 'Spree::TaxRate') and (adjustment.amount == 0) %>
+      <tr class="total">
+        <td colspan="4"><strong><%= adjustment.label %></strong></td>
+        <td class="total"><span><%= adjustment.display_amount.to_html %></span></td>
+      </tr>
+    <% end %>
+  </tfoot>
+
+</table>


### PR DESCRIPTION
closes #16 
This pull request includes the necessary changes on the checkout page for our project, very basic still.
In the api of solidus the order.rb model is the one who handles the checkout_flow, for this I needed to override that model to ignore the delivery shipment and payment steps.
Also overrides the views for future customization. 